### PR TITLE
Add `libpq-dev` and `phantomjs` to the list of pre-requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ You'll need:
   * on RHEL systems: `yum install postgresql-devel`  
   * for Mac: `brew install postgresql`  
   * for Mac in case postgres installed via macports than `gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin/pg_config`  
+* phantomjs
+  * `brew install phantomjs` 
+  * or `npm install -g phantomjs`
 
 Then, just run:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You'll need:
 * Bower
   * `npm install -g bower`
 * [Heroku Toolbelt](https://toolbelt.heroku.com)
+* `libpq-dev`  
+  on RHEL systems: `yum install postgresql-devel`  
+  for Mac: `brew install postgresql`  
+  for Mac in case postgres installed via macports than `gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin/pg_config`  
 
 Then, just run:
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ You'll need:
   * `npm install -g bower`
 * [Heroku Toolbelt](https://toolbelt.heroku.com)
 * `libpq-dev`  
-  on RHEL systems: `yum install postgresql-devel`  
-  for Mac: `brew install postgresql`  
-  for Mac in case postgres installed via macports than `gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin/pg_config`  
+  * on RHEL systems: `yum install postgresql-devel`  
+  * for Mac: `brew install postgresql`  
+  * for Mac in case postgres installed via macports than `gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin/pg_config`  
 
 Then, just run:
 


### PR DESCRIPTION
`pg` gem cannot be installed without `libpq-dev`. It fails with the error `Can't find the 'libpq-fe.h header`

---
Stackoverflow: http://stackoverflow.com/a/6040822/1005200