### PR TITLE
Pin Vue dependency at 1.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ You'll need:
 * Bower
   * `npm install -g bower`
 * [Heroku Toolbelt](https://toolbelt.heroku.com)
-* `libpq-dev`  
-  * on RHEL systems: `yum install postgresql-devel`  
-  * for Mac: `brew install postgresql`  
-  * for Mac in case postgres installed via macports than `gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin/pg_config`  
+* `libpq-dev`
+  * on RHEL systems: `yum install postgresql-devel`
+  * for Mac: `brew install postgresql`
+  * for Mac in case postgres installed via macports than `gem install pg -- --with-pg-config=/opt/local/lib/postgresql[version number]/bin/pg_config`
 * phantomjs
-  * `brew install phantomjs` 
+  * `brew install phantomjs`
   * or `npm install -g phantomjs`
 
 Then, just run:

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description": "Create beautiful images to share your content, in just a few clicks.",
   "private": true,
   "dependencies": {
-    "vue": "^1.0.16",
+    "vue": "1.0.17",
     "vue-resource": "^0.7.0",
     "foundation": "^5.5.3",
     "animate.css": "~3.5.1",


### PR DESCRIPTION
Seems like 1.0.18 may have some regressions, so we want to avoid that version for now.